### PR TITLE
Bazel: Fetch libMoltenVK rather than relying on system library

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,7 +35,12 @@ go_library(
         "vulkan_ios.go",
         "vulkan_linux.go",
     ],
-    cdeps = [":vulkan_headers"],
+    cdeps = [":vulkan_headers"] + select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "@com_github_goki_vulkan_mac_deps//:libmoltenvk_dylib",
+        ],
+        "//conditions:default": [],
+    }),
     cgo = True,
     clinkopts = select({
         "@io_bazel_rules_go//go/platform:android": [
@@ -50,11 +55,12 @@ go_library(
             "-framework IOSurface",
             "-framework QuartzCore",
             "-framework Metal",
-            "-lMoltenVK",
             "-lc++",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
-            "-L/usr/local/lib -ldl -lvulkan",
+            "-L/usr/local/lib",
+            "-ldl",
+            "-lvulkan",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "-ldl",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -11,6 +11,19 @@ http_archive(
     ],
 )
 
+# NOTE: consumers of this repository need to copy the following into their WORKSPACE
+
+vulkan_mac_deps_version = "1.3.211.0"
+
+http_archive(
+    name = "com_github_goki_vulkan_mac_deps",
+    sha256 = "8d3277edf13a29703fc8922e32cf6e15a67c2af67c89fb1bec4dc2bce3e0cbf6",
+    strip_prefix = "vulkan_mac_deps-%s" % vulkan_mac_deps_version,
+    url = "https://github.com/goki/vulkan_mac_deps/archive/refs/tags/%s.tar.gz" % vulkan_mac_deps_version,
+)
+
+# END NOTE
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()


### PR DESCRIPTION
This makes this target usable in Bazel without requiring the user to
install a compatible Vulkan SDK.