### PR TITLE
Rely on system installation of MoltenVK with Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,12 +35,7 @@ go_library(
         "vulkan_ios.go",
         "vulkan_linux.go",
     ],
-    cdeps = [":vulkan_headers"] + select({
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "@com_github_goki_vulkan_mac_deps//:libmoltenvk_dylib",
-        ],
-        "//conditions:default": [],
-    }),
+    cdeps = [":vulkan_headers"],
     cgo = True,
     clinkopts = select({
         "@io_bazel_rules_go//go/platform:android": [
@@ -55,6 +50,16 @@ go_library(
             "-framework IOSurface",
             "-framework QuartzCore",
             "-framework Metal",
+            # This line requires the Vulkan SDK to be installed.
+            # TODO: We should not require this.
+            # We can use cc_import and cdeps to link it, but the
+            # vulkan loader at run-time searches for the icd.d directory.
+            # I haven't figured out how to bundle that directory with this library.
+            # Maybe fixable by setting SYSCONFDIR once this is fixed:
+            # https://github.com/bazelbuild/bazel/issues/13930
+            # Reference:
+            # https://vulkan.lunarg.com/doc/view/1.3.211.0/mac/LoaderDriverInterface.html#user-content-driver-discovery-on-macos
+            "-lMoltenVK",
             "-lc++",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
@@ -71,13 +76,16 @@ go_library(
             "-framework Foundation",
             "-framework Metal",
             "-framework QuartzCore",
-            "-framework MoltenVK -lc++",
+            "-framework MoltenVK",
+            "-lc++",
         ],
         "//conditions:default": [],
     }),
     copts = [
         "-I.",
         "-DVK_NO_PROTOTYPES",
+        #
+        # "-DSYSCONFDIR=$(rootpath @com_github_goki_vulkan_mac_deps//:vulkan_mac_deps)/sdk/macOS/share",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "-DVK_USE_PLATFORM_ANDROID_KHR",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -11,19 +11,6 @@ http_archive(
     ],
 )
 
-# NOTE: consumers of this repository need to copy the following into their WORKSPACE
-
-vulkan_mac_deps_version = "1.3.211.0"
-
-http_archive(
-    name = "com_github_goki_vulkan_mac_deps",
-    sha256 = "8d3277edf13a29703fc8922e32cf6e15a67c2af67c89fb1bec4dc2bce3e0cbf6",
-    strip_prefix = "vulkan_mac_deps-%s" % vulkan_mac_deps_version,
-    url = "https://github.com/goki/vulkan_mac_deps/archive/refs/tags/%s.tar.gz" % vulkan_mac_deps_version,
-)
-
-# END NOTE
-
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()


### PR DESCRIPTION
The previous attempt to use a hermetic copy of it didn't work in all cases. The dylib was linked properly, but some Vulkan libraries at runtime access it through the "loader driver interface", which requires an `icd.d` directory to be present in a particular path.

See
https://vulkan.lunarg.com/doc/view/1.3.211.0/mac/LoaderDriverInterface.html#user-content-driver-discovery-on-macos

So for now we'll just rely on the user to install MoltenVK (probably via the LunarG Vulkan SDK), but I hope that maybe this is fixable once https://github.com/bazelbuild/bazel/issues/13930 is fixed.