### PR TITLE
make bazel build not rely on system Vulkan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .idea/
 *.iml
 
+# Bazel
+bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,7 +35,12 @@ go_library(
         "vulkan_ios.go",
         "vulkan_linux.go",
     ],
-    cdeps = [":vulkan_headers"],
+    cdeps = [":vulkan_headers"] + select({
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "@com_github_goki_vulkan_mac_deps//:vulkan_mac_deps",
+        ],
+        "//conditions:default": [],
+    }),
     cgo = True,
     clinkopts = select({
         "@io_bazel_rules_go//go/platform:android": [
@@ -50,16 +55,6 @@ go_library(
             "-framework IOSurface",
             "-framework QuartzCore",
             "-framework Metal",
-            # This line requires the Vulkan SDK to be installed.
-            # TODO: We should not require this.
-            # We can use cc_import and cdeps to link it, but the
-            # vulkan loader at run-time searches for the icd.d directory.
-            # I haven't figured out how to bundle that directory with this library.
-            # Maybe fixable by setting SYSCONFDIR once this is fixed:
-            # https://github.com/bazelbuild/bazel/issues/13930
-            # Reference:
-            # https://vulkan.lunarg.com/doc/view/1.3.211.0/mac/LoaderDriverInterface.html#user-content-driver-discovery-on-macos
-            "-lMoltenVK",
             "-lc++",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
@@ -84,8 +79,6 @@ go_library(
     copts = [
         "-I.",
         "-DVK_NO_PROTOTYPES",
-        #
-        # "-DSYSCONFDIR=$(rootpath @com_github_goki_vulkan_mac_deps//:vulkan_mac_deps)/sdk/macOS/share",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "-DVK_USE_PLATFORM_ANDROID_KHR",

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,10 +4,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "16e9fca53ed6bd4ff4ad76facc9b7b651a89db1689a2877d6fd7b82aa824e366",
+    sha256 = "dd926a88a564a9246713a9c00b35315f54cbd46b31a26d5d8fb264c07045f05d",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.34.0/rules_go-v0.34.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.34.0/rules_go-v0.34.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.38.1/rules_go-v0.38.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.38.1/rules_go-v0.38.1.zip",
     ],
 )
 
@@ -15,4 +15,30 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.18.5")
+go_register_toolchains(version = "1.18.10")
+
+vulkan_mac_deps_version = "1.3.239.0"
+
+http_archive(
+    name = "com_github_goki_vulkan_mac_deps",
+    sha256 = "348bc84c0fc1f1e79fb28bcf83454faa2a84c4d4c2286225d4413830a3c0a29c",
+    strip_prefix = "vulkan_mac_deps-%s" % vulkan_mac_deps_version,
+    url = "https://github.com/goki/vulkan_mac_deps/archive/refs/tags/%s.tar.gz" % vulkan_mac_deps_version,
+)
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+versions.check(minimum_bazel_version = "6.0.0")


### PR DESCRIPTION
No you can run `bazel build` or `bazel run` without installing the Vulkan SDK!